### PR TITLE
const username

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,7 +14,7 @@ configureOAuth({
 });
 
 async function login() {
-    username = document.getElementById("username").value
+    const username = document.getElementById("username").value
     const { identity, metadata } = await resolveFromIdentity(username);
     const authUrl = await createAuthorizationUrl({
         metadata: metadata,


### PR DESCRIPTION
On the brave browser, I was getting some weird errors about
```
script.js:17 Uncaught (in promise) ReferenceError: username is not defined
    at login (script.js:17:14)
    at HTMLButtonElement.onclick ((index):26:42)****
```
I think maybe due to some scoping rules? Anyways figured I would put in a patch. Will use this repo as a reference for BSky app auth, thanks!